### PR TITLE
Add remote find_files and live_grep functionality (all via SSH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ With this plugin you can:
 - Connect and mount a remote host via SSHFS using the `:RemoteSSHFSConnect` command. This command will trigger a picker to appear where you can select hosts that have been parsed from your SSH config files. Upon selecting a host, remote-sshfs will mount the host (by default at `~/.sshfs/<hostname>`) and change the current working directory to that folder. Additionally, by default, once vim closes the mount will be automatically unmounted and cleaned.
 - Disconnect from a remote host that you're current connected to using the `:RemoteSSHFSDisconnect` command
 - Select a SSH config to edit via a picker by using the `:RemoteSSHFSEdit` command
-- Utilize Telescope Find Files functionality completely remote via SSH by using the `:RemoteSSHFindFiles` command
+- Utilize Telescope Find Files functionality completely remote via SSH by using the `:RemoteSSHFindFiles` command (<strong>Note: the remote server must have either [ripgrep](https://github.com/BurntSushi/ripgrep), [fd/fdfind](https://github.com/sharkdp/fd), or the where command</strong>)
 - Utilize Telescope Live Grep functionality completely remote via SSH by using the `:RemoteSSHLiveGrep` command (<strong>Note: the remote server must have [ripgrep](https://github.com/BurntSushi/ripgrep) installed</strong>)
 
 <strong>Note:</strong> Currently only parsing hosts is supported, the ability to pass a host via the above commands will eventually be added

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ require('remote-sshfs').setup{
   handlers = {
     on_connect = {
       change_dir = true, -- when connected change vim working directory to mount point
-      find_files = false, -- when connected, run telescope find files
     },
     on_disconnect = {
       clean_mount_folders = false, -- remove mount point folder on disconnect/unmount

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 🚧 **(ALPHA/UNSTABLE) This plugin is currently being developed and may
 break or change frequently!** 🚧
 
-Explore, edit, and develop on a remote machine via SSHFS with Neovim. Loosely based on the VSCode extension [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh).
+Explore, edit, and develop on a remote machine via SSHFS with Neovim. Loosely based on the VSCode extension [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh). (Note: this plugin does not install packages on the remote server, instead it conducts finds, greps, etc over SSH and accesses files via SSHFS)
 
 ![Demo](https://github.com/nosduco/remote-sshfs.nvim/blob/main/demo.gif)
 
@@ -25,9 +25,11 @@ latest neovim nightly commit is required for `remote-sshfs.nvim` to work because
 
 ##### Neovim plugins
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
+- [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 
 ##### System dependencies
 - [sshfs](https://github.com/libfuse/sshfs)
+- [ssh](https://www.openssh.com/)
 
 ### Installation
 
@@ -94,8 +96,12 @@ With this plugin you can:
 - Connect and mount a remote host via SSHFS using the `:RemoteSSHFSConnect` command. This command will trigger a picker to appear where you can select hosts that have been parsed from your SSH config files. Upon selecting a host, remote-sshfs will mount the host (by default at `~/.sshfs/<hostname>`) and change the current working directory to that folder. Additionally, by default, once vim closes the mount will be automatically unmounted and cleaned.
 - Disconnect from a remote host that you're current connected to using the `:RemoteSSHFSDisconnect` command
 - Select a SSH config to edit via a picker by using the `:RemoteSSHFSEdit` command
+- Utilize Telescope Find Files functionality completely remote via SSH by using the `:RemoteSSHFindFiles` command
+- Utilize Telescope Live Grep functionality completely remote via SSH by using the `:RemoteSSHLiveGrep` command (<strong>Note: the remote server must have [ripgrep](https://github.com/BurntSushi/ripgrep) installed</strong>)
 
 <strong>Note:</strong> Currently only parsing hosts is supported, the ability to pass a host via the above commands will eventually be added
+
+To learn more about SSH configs and how to write/style one you can read more [here](https://linuxize.com/post/using-the-ssh-config-file/)
 
 For conveninece, it is recommended to setup keymappings for these commands.
 
@@ -170,6 +176,10 @@ Here's a list of the available commands:
 `:RemoteSSHFSDisconnect`: Use this command to disconnect from a connected host
 
 `:RemoteSSHFSEdit`: Use this command to open the ssh config picker to open and edit ssh configs
+
+`:RemoteSSHFSFindFiles`: Use this command to initiate a telescope find files window which operates completely remotely via SSH and will open buffers referencing to your local mount
+
+`:RemoteSSHFSLiveGrep`: Use this command to initiate a telescope live grep window which operates completely remotely via SSH and will open buffers referencing to your local mount
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ local api = require('remote-sshfs.api')
 vim.keymap.set('n', '<leader>rc', api.connect, {})
 vim.keymap.set('n', '<leader>rd', api.disconnect, {})
 vim.keymap.set('n', '<leader>re', api.edit, {})
+
+-- (optional) Override telescope find_files and live_grep to make dynamic based on if connected to host
+local builtin = require("telescope.builtin")
+local connections = require("remote-sshfs.connections")
+vim.keymap.set("n", "<leader>ff", function()
+	if connections.is_connected then
+		api.find_files()
+	else
+		builtin.find_files()
+	end
+end, {})
+vim.keymap.set("n", "<leader>fg", function()
+	if connections.is_connected then
+		api.live_grep()
+	else
+		builtin.live_grep()
+	end
+end, {})
 ```
 
 ## Customization

--- a/lua/remote-sshfs/api.lua
+++ b/lua/remote-sshfs/api.lua
@@ -22,4 +22,14 @@ M.reload = function()
   connections.reload()
 end
 
+-- Trigger remote find_files
+M.find_files = function()
+  require("telescope").extensions["remote-sshfs"].find_files()
+end
+
+-- Trigger remote live_grep
+M.live_grep = function()
+  require("telescope").extensions["remote-sshfs"].live_grep()
+end
+
 return M

--- a/lua/remote-sshfs/connections.lua
+++ b/lua/remote-sshfs/connections.lua
@@ -19,6 +19,13 @@ M.setup = function(opts)
   hosts = utils.parse_hosts_from_configs(ssh_configs)
 end
 
+M.is_connected = function()
+  if sshfs_job_id and mount_point then
+    return true
+  end
+  return false
+end
+
 M.list_hosts = function()
   return hosts
 end

--- a/lua/remote-sshfs/connections.lua
+++ b/lua/remote-sshfs/connections.lua
@@ -7,6 +7,7 @@ local hosts = {}
 local ssh_configs = {}
 local sshfs_args = {}
 local sshfs_job_id = nil
+local mount_point = nil
 
 local M = {}
 
@@ -24,6 +25,10 @@ end
 
 M.list_ssh_configs = function()
   return ssh_configs
+end
+
+M.get_current_mount_point = function()
+  return mount_point
 end
 
 M.reload = function()
@@ -112,6 +117,7 @@ M.mount_host = function(host, mount_dir, ask_pass)
 
     vim.notify("Connecting to host (" .. remote_host .. ")...")
     local skip_clean = false
+    mount_point = mount_dir .. "/"
     sshfs_job_id = vim.fn.jobstart(sshfs_cmd_local, {
       cwd = mount_dir,
       on_stdout = function(_, data)
@@ -145,6 +151,7 @@ M.unmount_host = function()
     -- Kill the SSHFS process
     vim.fn.jobstop(sshfs_job_id)
   end
+  mount_point = nil
 end
 
 return M

--- a/lua/remote-sshfs/handler.lua
+++ b/lua/remote-sshfs/handler.lua
@@ -49,17 +49,12 @@ M.authenticated_handler = function(mount_dir)
       utils.change_directory(mount_dir)
     end
   end
-
-  if M.find_files then
-    utils.find_files()
-  end
 end
 
 M.setup = function(opts)
   M.clean_mount_folders = opts.handlers.on_disconnect.clean_mount_folders
   M.change_dir = opts.handlers.on_connect.change_dir
   M.confirm_change_dir = opts.ui.confirm.change_dir
-  M.find_files = opts.handlers.on_connect.find_files
 end
 
 return M

--- a/lua/remote-sshfs/init.lua
+++ b/lua/remote-sshfs/init.lua
@@ -19,7 +19,6 @@ local default_opts = {
   handlers = {
     on_connect = {
       change_dir = true,
-      find_files = false,
     },
     on_disconnect = {
       clean_mount_folders = false,

--- a/lua/remote-sshfs/init.lua
+++ b/lua/remote-sshfs/init.lua
@@ -57,9 +57,20 @@ M.setup_commands = function()
   vim.api.nvim_create_user_command("RemoteSSHFSReload", function()
     require("remote-sshfs.connections").reload()
   end, {})
-  vim.api.nvim_create_user_command("RemoteSSHFSDisconnect", function() end, {
-    require("remote-sshfs.connections").unmount_host(),
-  })
+  vim.api.nvim_create_user_command("RemoteSSHFSDisconnect", function()
+    require("remote-sshfs.connections").unmount_host()
+  end, {})
+
+  vim.api.nvim_create_user_command("RemoteSSHFSFindFiles", function()
+    require("telescope").extensions["remote-sshfs"].find_files({})
+  end, {})
+
+  -- vim.api.nvim_create_user_command("RemoteSSHFSTestLG", function()
+  --   local builtin = require "telescope.builtin"
+  --   builtin.live_grep {
+  --     find_command = { "ssh", "tux", "-C", "fdfind", "--type", "f", "--color", "never" },
+  --   }
+  -- end, {})
 end
 
 M.setup = function(config)

--- a/lua/remote-sshfs/init.lua
+++ b/lua/remote-sshfs/init.lua
@@ -65,6 +65,10 @@ M.setup_commands = function()
     require("telescope").extensions["remote-sshfs"].find_files({})
   end, {})
 
+  vim.api.nvim_create_user_command("RemoteSSHFSLiveGrep", function()
+    require("telescope").extensions["remote-sshfs"].live_grep({})
+  end, {})
+
   -- vim.api.nvim_create_user_command("RemoteSSHFSTestLG", function()
   --   local builtin = require "telescope.builtin"
   --   builtin.live_grep {

--- a/lua/remote-sshfs/init.lua
+++ b/lua/remote-sshfs/init.lua
@@ -47,7 +47,7 @@ local default_opts = {
 }
 
 M.setup_commands = function()
-  -- Create commands to connect/edit/reload/disconnect
+  -- Create commands to connect/edit/reload/disconnect/find_files/live_grep
   vim.api.nvim_create_user_command("RemoteSSHFSConnect", function()
     require("telescope").extensions["remote-sshfs"].connect()
   end, {})
@@ -60,21 +60,12 @@ M.setup_commands = function()
   vim.api.nvim_create_user_command("RemoteSSHFSDisconnect", function()
     require("remote-sshfs.connections").unmount_host()
   end, {})
-
   vim.api.nvim_create_user_command("RemoteSSHFSFindFiles", function()
     require("telescope").extensions["remote-sshfs"].find_files({})
   end, {})
-
   vim.api.nvim_create_user_command("RemoteSSHFSLiveGrep", function()
     require("telescope").extensions["remote-sshfs"].live_grep({})
   end, {})
-
-  -- vim.api.nvim_create_user_command("RemoteSSHFSTestLG", function()
-  --   local builtin = require "telescope.builtin"
-  --   builtin.live_grep {
-  --     find_command = { "ssh", "tux", "-C", "fdfind", "--type", "f", "--color", "never" },
-  --   }
-  -- end, {})
 end
 
 M.setup = function(config)

--- a/lua/remote-sshfs/init.lua
+++ b/lua/remote-sshfs/init.lua
@@ -60,10 +60,10 @@ M.setup_commands = function()
     require("remote-sshfs.connections").unmount_host()
   end, {})
   vim.api.nvim_create_user_command("RemoteSSHFSFindFiles", function()
-    require("telescope").extensions["remote-sshfs"].find_files({})
+    require("telescope").extensions["remote-sshfs"].find_files {}
   end, {})
   vim.api.nvim_create_user_command("RemoteSSHFSLiveGrep", function()
-    require("telescope").extensions["remote-sshfs"].live_grep({})
+    require("telescope").extensions["remote-sshfs"].live_grep {}
   end, {})
 end
 

--- a/lua/remote-sshfs/utils.lua
+++ b/lua/remote-sshfs/utils.lua
@@ -88,8 +88,4 @@ M.change_directory = function(path)
   vim.notify("Directory changed to " .. path)
 end
 
-M.find_files = function()
-  vim.cmd ":Telescope find_files"
-end
-
 return M

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -1,6 +1,7 @@
 local sorters = require "telescope.sorters"
 local state = require "telescope.actions.state"
 local previewers = require "telescope.previewers"
+local log = require "remote-sshfs.log"
 
 -- Build virtualized host file from parsed hosts from plugin
 local function build_host_preview(hosts, name)
@@ -112,6 +113,140 @@ local function edit_config(_)
     :find()
 end
 
+-- Remote find_files implementation
+local function find_files(opts)
+  local pickers, finders, from_entry, conf, make_entry, flatten
+  if pcall(require, "telescope") then
+    pickers = require "telescope.pickers"
+    finders = require "telescope.finders"
+    previewers = require "telescope.previewers"
+    from_entry = require "telescope.from_entry"
+    conf = require("telescope.config").values
+    make_entry = require "telescope.make_entry"
+    flatten = vim.tbl_flatten
+  else
+    error "Cannot find telescope!"
+  end
+
+  local Path
+  if pcall(require, "plenary.path") then
+    Path = require "plenary.path"
+  else
+    error "Cannot find plenary"
+  end
+
+  local connections
+  if pcall(require, "remote-sshfs") then
+    connections = require "remote-sshfs.connections"
+  else
+    error "Cannot find remote-sshfs"
+  end
+
+  -- Setup
+  local find_command = { "ssh", "tux", "-C", "fdfind", "--type", "f", "--color", "never" }
+  local mount_point = opts.mount_point or connections.get_current_mount_point()
+
+  -- Core find_files functionality
+  local command = find_command[1]
+  local hidden = opts.hidden
+  local no_ignore = opts.no_ignore
+  local no_ignore_parent = opts.no_ignore_parent
+  local follow = opts.follow
+  local search_dirs = opts.search_dirs
+  local search_file = opts.search_file
+
+  if command == "fd" or command == "fdfind" or command == "rg" then
+    if hidden then
+      find_command[#find_command + 1] = "--hidden"
+    end
+    if no_ignore then
+      find_command[#find_command + 1] = "--no-ignore"
+    end
+    if no_ignore_parent then
+      find_command[#find_command + 1] = "--no-ignore-parent"
+    end
+    if follow then
+      find_command[#find_command + 1] = "-L"
+    end
+    if search_file then
+      if command == "rg" then
+        find_command[#find_command + 1] = "-g"
+        find_command[#find_command + 1] = "*" .. search_file .. "*"
+      else
+        find_command[#find_command + 1] = search_file
+      end
+    end
+    if search_dirs then
+      if command ~= "rg" and not search_file then
+        find_command[#find_command + 1] = "."
+      end
+      vim.list_extend(find_command, search_dirs)
+    end
+  elseif command == "find" then
+    if not hidden then
+      table.insert(find_command, { "-not", "-path", "*/.*" })
+      find_command = flatten(find_command)
+    end
+    if follow then
+      table.insert(find_command, 2, "-L")
+    end
+    if search_file then
+      table.insert(find_command, "-name")
+      table.insert(find_command, "*" .. search_file .. "*")
+    end
+    if search_dirs then
+      table.remove(find_command, 2)
+      for _, v in pairs(search_dirs) do
+        table.insert(find_command, 2, v)
+      end
+    end
+    -- TODO: Add error logging here
+  end
+
+  if opts.cwd then
+    opts.cwd = vim.fn.expand(opts.cwd)
+  end
+
+  opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
+
+  if search_dirs then
+    for k, v in pairs(search_dirs) do
+      search_dirs[k] = vim.fn.expand(v)
+    end
+  end
+  local cwd = opts.cwd or vim.loop.cwd()
+  pickers
+    .new(opts, {
+      prompt_title = "Find Files",
+      finder = finders.new_oneshot_job(find_command, opts),
+      previewer = previewers.new_buffer_previewer {
+        title = "File Preview",
+        dyn_title = function(_, entry)
+          return Path:new(from_entry.path(entry, false, false)):normalize(cwd)
+        end,
+
+        get_buffer_by_name = function(_, entry)
+          return from_entry.path(entry, false)
+        end,
+
+        define_preview = function(self, entry, status)
+          entry.path = mount_point .. entry.filename
+          local p = from_entry.path(entry, true)
+          if p == nil or p == "" then
+            return
+          end
+          conf.buffer_previewer_maker(p, self.state.bufnr, {
+            bufname = self.state.bufname,
+            winid = self.state.winid,
+            preview = opts.preview,
+          })
+        end,
+      },
+      sorter = conf.file_sorter(opts),
+    })
+    :find()
+end
+
 -- Initialize with telescope
 local present, telescope = pcall(require, "telescope")
 if present then
@@ -122,6 +257,9 @@ if present then
       end,
       edit = function(_)
         edit_config(_)
+      end,
+      find_files = function(opts)
+        find_files(opts)
       end,
     },
   }

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -124,7 +124,7 @@ local function find_files(opts)
   end
 
   -- Check that a connection exists
-  if not connections.get_current_mount_point() then
+  if not connections.is_connected() then
     vim.notify "You are not currently connected to a remote host."
     return
   end
@@ -150,8 +150,9 @@ local function find_files(opts)
   end
 
   -- Setup
-  local find_command = { "ssh", "tux", "-C", "fdfind", "--type", "f", "--color", "never" }
   local mount_point = opts.mount_point or connections.get_current_mount_point()
+  local current_host = connections.get_current_host()
+  local find_command = { "ssh", current_host["Name"], "-C", "fdfind", "--type", "f", "--color", "never" }
 
   -- Core find_files functionality
   local command = find_command[1]
@@ -224,10 +225,10 @@ local function find_files(opts)
   local cwd = opts.cwd or vim.loop.cwd()
   pickers
     .new(opts, {
-      prompt_title = "Find Files",
+      prompt_title = "Remote Find Files",
       finder = finders.new_oneshot_job(find_command, opts),
       previewer = previewers.new_buffer_previewer {
-        title = "File Preview",
+        title = "Remote File Preview",
         dyn_title = function(_, entry)
           return Path:new(from_entry.path(entry, false, false)):normalize(cwd)
         end,
@@ -295,7 +296,7 @@ local function live_grep(opts)
   end
 
   -- Check that a connection exists
-  if not connections.get_current_mount_point() then
+  if not connections.is_connected() then
     vim.notify "You are not currently connected to a remote host."
     return
   end
@@ -322,10 +323,11 @@ local function live_grep(opts)
   end
 
   -- Setup
+  local current_host = connections.get_current_host()
   local mount_point = opts.mount_point or connections.get_current_mount_point()
   local vimgrep_arguments = {
     "ssh",
-    "tux",
+    current_host["Name"],
     "-C",
     "rg",
     "--color=never",
@@ -393,11 +395,11 @@ local function live_grep(opts)
 
   pickers
     .new(opts, {
-      prompt_title = "Live Grep",
+      prompt_title = "Remote Live Grep",
       finder = live_grepper,
       -- previewer = conf.grep_previewer(opts),
       previewer = previewers.new_buffer_previewer {
-        title = "Grep Preview",
+        title = "Remote Grep Preview",
         dyn_title = function(_, entry)
           return Path:new(from_entry.path(entry, false, false)):normalize(opts.cwd)
         end,

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -155,7 +155,7 @@ local function find_files(opts)
   local find_command = { "ssh", current_host["Name"], "-C", "fdfind", "--type", "f", "--color", "never" }
 
   -- Core find_files functionality
-  local command = find_command[1]
+  local command = find_command[3]
   local hidden = opts.hidden
   local no_ignore = opts.no_ignore
   local no_ignore_parent = opts.no_ignore_parent
@@ -196,16 +196,16 @@ local function find_files(opts)
       find_command = flatten(find_command)
     end
     if follow then
-      table.insert(find_command, 2, "-L")
+      table.insert(find_command, 5, "-L")
     end
     if search_file then
       table.insert(find_command, "-name")
       table.insert(find_command, "*" .. search_file .. "*")
     end
     if search_dirs then
-      table.remove(find_command, 2)
+      table.remove(find_command, 5)
       for _, v in pairs(search_dirs) do
-        table.insert(find_command, 2, v)
+        table.insert(find_command, 5, v)
       end
     end
     -- TODO: Add error logging here

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -235,7 +235,6 @@ local function find_files(opts)
         table.insert(find_command, 5, v)
       end
     end
-    -- TODO: Add error logging here
   end
 
   if opts.cwd then
@@ -424,7 +423,6 @@ local function live_grep(opts)
     .new(opts, {
       prompt_title = "Remote Live Grep",
       finder = live_grepper,
-      -- previewer = conf.grep_previewer(opts),
       previewer = previewers.new_buffer_previewer {
         title = "Remote Grep Preview",
         dyn_title = function(_, entry)

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -177,7 +177,7 @@ local function find_files(opts)
   end)()
 
   if not find_command then
-    vim.notify "Remote host does not support any available find commands (rg, fd, fdfind, where). Please install and try again."
+    vim.notify "Remote host does not support any available find commands (rg, fd, fdfind, where)."
     return
   end
 

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -2,6 +2,7 @@ local sorters = require "telescope.sorters"
 local state = require "telescope.actions.state"
 local previewers = require "telescope.previewers"
 local log = require "remote-sshfs.log"
+local ns_previewer = vim.api.nvim_create_namespace "telescope.previewers"
 
 -- Build virtualized host file from parsed hosts from plugin
 local function build_host_preview(hosts, name)
@@ -115,6 +116,19 @@ end
 
 -- Remote find_files implementation
 local function find_files(opts)
+  local connections
+  if pcall(require, "remote-sshfs") then
+    connections = require "remote-sshfs.connections"
+  else
+    error "Cannot find remote-sshfs"
+  end
+
+  -- Check that a connection exists
+  if not connections.get_current_mount_point() then
+    vim.notify "You are not currently connected to a remote host."
+    return
+  end
+
   local pickers, finders, from_entry, conf, make_entry, flatten
   if pcall(require, "telescope") then
     pickers = require "telescope.pickers"
@@ -133,13 +147,6 @@ local function find_files(opts)
     Path = require "plenary.path"
   else
     error "Cannot find plenary"
-  end
-
-  local connections
-  if pcall(require, "remote-sshfs") then
-    connections = require "remote-sshfs.connections"
-  else
-    error "Cannot find remote-sshfs"
   end
 
   -- Setup
@@ -229,7 +236,7 @@ local function find_files(opts)
           return from_entry.path(entry, false)
         end,
 
-        define_preview = function(self, entry, status)
+        define_preview = function(self, entry, _)
           entry.path = mount_point .. entry.filename
           local p = from_entry.path(entry, true)
           if p == nil or p == "" then
@@ -247,6 +254,195 @@ local function find_files(opts)
     :find()
 end
 
+-- Utility function
+local opts_contain_invert = function(args)
+  local invert = false
+  local files_with_matches = false
+
+  for _, v in ipairs(args) do
+    if v == "--invert-match" then
+      invert = true
+    elseif v == "--files-with-matches" or v == "--files-without-match" then
+      files_with_matches = true
+    end
+
+    if #v >= 2 and v:sub(1, 1) == "-" and v:sub(2, 2) ~= "-" then
+      local non_option = false
+      for i = 2, #v do
+        local vi = v:sub(i, i)
+        if vi == "=" then -- ignore option -g=xxx
+          break
+        elseif vi == "g" or vi == "f" or vi == "m" or vi == "e" or vi == "r" or vi == "t" or vi == "T" then
+          non_option = true
+        elseif non_option == false and vi == "v" then
+          invert = true
+        elseif non_option == false and vi == "l" then
+          files_with_matches = true
+        end
+      end
+    end
+  end
+  return invert, files_with_matches
+end
+
+-- Remote live_grep implementation
+local function live_grep(opts)
+  local connections
+  if pcall(require, "remote-sshfs") then
+    connections = require "remote-sshfs.connections"
+  else
+    error "Cannot find remote-sshfs"
+  end
+
+  -- Check that a connection exists
+  if not connections.get_current_mount_point() then
+    vim.notify "You are not currently connected to a remote host."
+    return
+  end
+
+  local pickers, finders, from_entry, actions, conf, make_entry, flatten
+  if pcall(require, "telescope") then
+    pickers = require "telescope.pickers"
+    finders = require "telescope.finders"
+    previewers = require "telescope.previewers"
+    actions = require "telescope.actions"
+    from_entry = require "telescope.from_entry"
+    conf = require("telescope.config").values
+    make_entry = require "telescope.make_entry"
+    flatten = vim.tbl_flatten
+  else
+    error "Cannot find telescope!"
+  end
+
+  local Path
+  if pcall(require, "plenary.path") then
+    Path = require "plenary.path"
+  else
+    error "Cannot find plenary"
+  end
+
+  -- Setup
+  local mount_point = opts.mount_point or connections.get_current_mount_point()
+  local vimgrep_arguments = {
+    "ssh",
+    "tux",
+    "-C",
+    "rg",
+    "--color=never",
+    "--no-heading",
+    "--with-filename",
+    "--line-number",
+    "--column",
+    "--smart-case",
+  }
+  -- TODO: Handle if server does not have RIPGREP
+
+  local search_dirs = opts.search_dirs
+  opts.cwd = opts.cwd and vim.fn.expand(opts.cwd) or vim.loop.cwd()
+
+  if search_dirs then
+    for i, path in ipairs(search_dirs) do
+      search_dirs[i] = vim.fn.expand(path)
+    end
+  end
+
+  local additional_args = {}
+  if opts.additional_args ~= nil then
+    if type(opts.additional_args) == "function" then
+      additional_args = opts.additional_args(opts)
+    elseif type(opts.additional_args) == "table" then
+      additional_args = opts.additional_args
+    end
+  end
+
+  if opts.type_filter then
+    additional_args[#additional_args + 1] = "--type=" .. opts.type_filter
+  end
+
+  if type(opts.glob_pattern) == "string" then
+    additional_args[#additional_args + 1] = "--glob=" .. opts.glob_pattern
+  elseif type(opts.glob_pattern) == "table" then
+    for i = 1, #opts.glob_pattern do
+      additional_args[#additional_args + 1] = "--glob=" .. opts.glob_pattern[i]
+    end
+  end
+
+  local args = flatten { vimgrep_arguments, additional_args }
+  opts.__inverted, opts.__matches = opts_contain_invert(args)
+
+  local live_grepper = finders.new_job(function(prompt)
+    if not prompt or prompt == "" then
+      return nil
+    end
+
+    local search_list = search_dirs
+    local flattened = flatten { args, "--", prompt, search_list, "." }
+    return flattened
+  end, opts.entry_maker or make_entry.gen_from_vimgrep(opts), opts.max_results, opts.cwd)
+
+  local jump_to_line = function(self, bufnr, lnum)
+    pcall(vim.api.nvim_buf_clear_namespace, bufnr, ns_previewer, 0, -1)
+    if lnum and lnum > 0 then
+      pcall(vim.api.nvim_buf_add_highlight, bufnr, ns_previewer, "TelescopePreviewLine", lnum - 1, 0, -1)
+      pcall(vim.api.nvim_win_set_cursor, self.state.winid, { lnum, 0 })
+      vim.api.nvim_buf_call(bufnr, function()
+        vim.cmd "norm! zz"
+      end)
+    end
+  end
+
+  pickers
+    .new(opts, {
+      prompt_title = "Live Grep",
+      finder = live_grepper,
+      -- previewer = conf.grep_previewer(opts),
+      previewer = previewers.new_buffer_previewer {
+        title = "Grep Preview",
+        dyn_title = function(_, entry)
+          return Path:new(from_entry.path(entry, false, false)):normalize(opts.cwd)
+        end,
+
+        get_buffer_by_name = function(_, entry)
+          return from_entry.path(entry, false)
+        end,
+
+        define_preview = function(self, entry, _)
+          entry.path = mount_point .. entry.filename
+          log.line(vim.inspect(entry))
+          local has_buftype = entry.bufnr and vim.api.nvim_buf_get_option(entry.bufnr, "buftype") ~= "" or false
+          local p
+          if not has_buftype then
+            p = from_entry.path(entry, true)
+            if p == nil or p == "" then
+              return
+            end
+          end
+
+          if entry.bufnr and (p == "[No Name]" or has_buftype) then
+            local lines = vim.api.nvim_buf_get_lines(entry.bufnr, 0, -1, false)
+            vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+            jump_to_line(self, self.state.bufnr, entry.lnum)
+          else
+            conf.buffer_previewer_maker(p, self.state.bufnr, {
+              bufname = self.state.bufname,
+              winid = self.state.winid,
+              preview = opts.preview,
+              callback = function(bufnr)
+                jump_to_line(self, bufnr, entry.lnum)
+              end,
+            })
+          end
+        end,
+      },
+      sorter = sorters.highlighter_only(opts),
+      attach_mappings = function(_, map)
+        map("i", "<c-space>", actions.to_fuzzy_refine)
+        return true
+      end,
+    })
+    :find()
+end
+
 -- Initialize with telescope
 local present, telescope = pcall(require, "telescope")
 if present then
@@ -260,6 +456,9 @@ if present then
       end,
       find_files = function(opts)
         find_files(opts)
+      end,
+      live_grep = function(opts)
+        live_grep(opts)
       end,
     },
   }


### PR DESCRIPTION
Hey all! This is a PR based on feedback from Reddit on adding useful functionality to get closer to the remote development VS Code offers.

This PR adds 2 new commands `:RemoteSSHFSFindFiles` and `:RemoteSSHFSLiveGrep` which both trigger the same functionality you'd expect with regular telescope find files and live grep, but conducts it over SSH to offload all the I/O work and then opens up the locally mounted files when selected. 

I've added an example keymapping to the README such that you can use your same telescope mappings and if you are connected to a host it will trigger remote and regular if not.

Please keep the feedback coming!

Changelog:
- Add remote find_files implementation via SSH
- Add remote live_grep implementation via SSH
- Add new commands to trigger new functionality
- Configure remote find_files and live_grep to use respective hosts and mount point (regardless of cwd)
- Remove old auto find_files functionality
- Update README with changes and example configs
- Enhance find_files command builder to check if remote server has necessary package (ripgrep, fd, etc)
- Cleanup telescope extension