### PR TITLE
Remove cwd from jobstart

### DIFF
--- a/lua/remote-sshfs/connections.lua
+++ b/lua/remote-sshfs/connections.lua
@@ -134,7 +134,6 @@ M.mount_host = function(host, mount_dir, ask_pass)
     mount_point = mount_dir .. "/"
     current_host = host
     sshfs_job_id = vim.fn.jobstart(sshfs_cmd_local, {
-      cwd = mount_dir,
       on_stdout = function(_, data)
         handler.sshfs_wrapper(data, mount_dir, function(event)
           if event == "ask_pass" then


### PR DESCRIPTION
The process will hang if we change the working directory to the mount location before sshfs was able to mount the remote.