### PR TITLE
fix: remove hard-coded remote /home directory

### DIFF
--- a/lua/remote-sshfs/connections.lua
+++ b/lua/remote-sshfs/connections.lua
@@ -115,7 +115,7 @@ M.mount_host = function(host, mount_dir, ask_pass)
   if host["Path"] then
     sshfs_cmd = sshfs_cmd .. ":" .. host["Path"] .. " "
   else
-    sshfs_cmd = sshfs_cmd .. ":/home/" .. user .. "/ "
+    sshfs_cmd = sshfs_cmd .. ": "
   end
 
   sshfs_cmd = sshfs_cmd .. mount_dir


### PR DESCRIPTION
Allow connections:
- as root to Linux hosts (in /root home directory)
- to macOS hosts (with /Users/* home directories)

Fixes #9 