### PR TITLE
fix: fix keybinds example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ vim.keymap.set('n', '<leader>re', api.edit, {})
 local builtin = require("telescope.builtin")
 local connections = require("remote-sshfs.connections")
 vim.keymap.set("n", "<leader>ff", function()
- if connections.is_connected then
+ if connections.is_connected() then
   api.find_files()
  else
   builtin.find_files()
  end
 end, {})
 vim.keymap.set("n", "<leader>fg", function()
- if connections.is_connected then
+ if connections.is_connected() then
   api.live_grep()
  else
   builtin.live_grep()

--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -156,6 +156,7 @@ local function find_files(opts)
   end
 
   -- Setup
+  opts = opts or {}
   local mount_point = opts.mount_point or connections.get_current_mount_point()
   local current_host = connections.get_current_host()
 
@@ -349,6 +350,7 @@ local function live_grep(opts)
   end
 
   -- Setup
+  opts = opts or {}
   local current_host = connections.get_current_host()
   local mount_point = opts.mount_point or connections.get_current_mount_point()
   local vimgrep_arguments = {


### PR DESCRIPTION
- Fix `is_connected` to `is_connected()`;
- Add default value for `opts` in `find_files` and `live_grep` functions.