### PR TITLE
Add configurable default remote directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ require('remote-sshfs').setup{
   mounts = {
     base_dir = vim.fn.expand "$HOME" .. "/.sshfs/", -- base directory for mount points
     unmount_on_exit = true, -- run sshfs as foreground, will unmount on vim exit
+    remote_dir = "", -- remote directory to mount, by default home directory of connecting user
   },
   handlers = {
     on_connect = {

--- a/lua/remote-sshfs/connections.lua
+++ b/lua/remote-sshfs/connections.lua
@@ -119,7 +119,7 @@ M.mount_host = function(host, mount_dir, ask_pass)
   if host["Path"] then
     sshfs_cmd = sshfs_cmd .. ":" .. host["Path"] .. " "
   else
-    sshfs_cmd = sshfs_cmd .. ": "
+    sshfs_cmd = sshfs_cmd .. ":" .. config.mounts.remote_dir .. " "
   end
 
   sshfs_cmd = sshfs_cmd .. mount_dir


### PR DESCRIPTION
On a lot of machines I administrate I want to mount a different directory than the home directory by default. I added another config parameter that will be concatenated onto the mount path if not one is specified. The example config contains an empty string to keep current behavior.