### PR TITLE
fix: rename enable to enabled to fix mismatched config option for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ require('remote-sshfs').setup{
     },
   },
   log = {
-    enable = false, -- enable logging
+    enabled = false, -- enable logging
     truncate = false, -- truncate logs
     types = { -- enabled log types
       all = false,

--- a/lua/remote-sshfs/init.lua
+++ b/lua/remote-sshfs/init.lua
@@ -34,7 +34,7 @@ local default_opts = {
     },
   },
   log = {
-    enable = false,
+    enabled = false,
     truncate = false,
     types = {
       all = false,


### PR DESCRIPTION
Changed README and default configuration to use enabled instead of
enable. This is a typo and enabled is used in log.lua
