### PR TITLE
fix: go back to normal mode when connect

### DIFF
--- a/lua/telescope/_extensions/remote-sshfs.lua
+++ b/lua/telescope/_extensions/remote-sshfs.lua
@@ -65,6 +65,10 @@ local function connect(_)
           local host = hosts[selection[1]]
 
           connections.connect(host)
+
+          vim.schedule(function()
+            vim.cmd "stopinsert"
+          end)
         end)
         return true
       end,


### PR DESCRIPTION
Fix `:RemoteSSHFSConnect` doesn't return to normal mode when finish running