### PR TITLE
Add ability to set Path option in .sshconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ With this plugin you can:
 To learn more about SSH configs and how to write/style one you can read more [here](https://linuxize.com/post/using-the-ssh-config-file/)
 
 
+### Custom `Path` Option
+
+`Path` is **not** a valid OpenSSH option — adding it directly to `~/.ssh/config` will fail.  
+Instead, store it as a comment so SSH ignores it but the plugin can read it:
+
+```sshconfig
+Host my-alias
+    HostName example.com
+    User myuser
+    # Path=/home/myuser/projects
+```
+
+
 ### 🔔 Callback
 
 You can manage callbacks on events like `on_connect_success` using the following methods:

--- a/lua/remote-sshfs/utils.lua
+++ b/lua/remote-sshfs/utils.lua
@@ -55,6 +55,13 @@ M.parse_hosts_from_configs = function(ssh_configs)
     local current_config = vim.fn.expand(path)
     if vim.fn.filereadable(current_config) == 1 then
       for line in io.lines(current_config) do
+        -- Check for our custom Path comment
+        local path_value = line:match "^%s*#%s*Path=(.+)$"
+        if path_value and #current_hosts > 0 then
+          for _, host in ipairs(current_hosts) do
+            hosts[host]["Path"] = path_value
+          end
+        end
         -- Ignore comments and empty lines
         if line:sub(1, 1) ~= "#" and line:match "%S" then
           -- Check if the line is a Host entry


### PR DESCRIPTION
The path can be set as a comment like this:
```sshconfig
Host my-alias
    HostName example.com
    User myuser
    # Path=/home/myuser/projects
```

I know this is a  bit hacky, but it's the only way I think it would work for .sshconfig