### PR TITLE
fix: fix trailing whitespace breaking known-hosts parsing

### DIFF
--- a/lua/remote-sshfs/connections.lua
+++ b/lua/remote-sshfs/connections.lua
@@ -165,9 +165,17 @@ M.mount_host = function(host, mount_dir, ask_pass)
       return
     end
 
-    -- Parse the first key to get its fingerprint
-    local first_key_line = vim.split(scan_result, "\n")[1]
-    if not first_key_line or first_key_line == "" then
+    -- Parse the first non-comment, non-empty key line to get its fingerprint.
+    -- ssh-keyscan emits "# host:port SSH-version" banner lines to stdout,
+    -- so we skip them rather than feeding them to ssh-keygen -lf.
+    local first_key_line
+    for _, line in ipairs(vim.split(scan_result, "\n")) do
+      if line ~= "" and line:sub(1, 1) ~= "#" then
+        first_key_line = line
+        break
+      end
+    end
+    if not first_key_line then
       vim.notify("No valid host keys found for " .. hostname, vim.log.levels.ERROR)
       return
     end

--- a/lua/remote-sshfs/utils.lua
+++ b/lua/remote-sshfs/utils.lua
@@ -75,7 +75,7 @@ M.parse_hosts_from_configs = function(ssh_configs)
           else
             -- If the line is not a Host entry, but there are current hosts, add the line to their attributes
             if #current_hosts > 0 then
-              local key, value = line:match "^%s*(%S+)%s+(.+)$"
+              local key, value = line:match "^%s*(%S+)%s+(.-)%s*$"
               if key and value then
                 for _, host in ipairs(current_hosts) do
                   hosts[host][key] = value


### PR DESCRIPTION
This PR fixes this issue https://github.com/nosduco/remote-sshfs.nvim/issues/70

There was a bug when parsing know-hosts where trailing whitespace would break the parsing leading to the following error:

"Could not parse fingerprint for HOST"

I have tested this change locally and can now properly connect using remote-sshfs on macos.